### PR TITLE
Unsetting single config value does not empty config

### DIFF
--- a/lib/codeunion/config.rb
+++ b/lib/codeunion/config.rb
@@ -57,6 +57,7 @@ module CodeUnion
       else
         config.delete(key)
       end
+      config
     end
 
     def get_dotted(config, dotted_key)

--- a/test/features/config_test.rb
+++ b/test/features/config_test.rb
@@ -16,8 +16,12 @@ class TestCodunionConfigFeature < MiniTest::Test
 
   def test_unsetting_a_value
     config("set test.value 'new_value'")
+    config("set test.other 'brother'")
     config("unset test.value")
     actual = config("get test.value").strip()
     assert_equal "", actual
+
+    actual = config("get test.other").strip()
+    assert_equal "brother", actual
   end
 end


### PR DESCRIPTION
Fixes #23, 

```
$ bin/codeunion-config --set hello.other other
$ bin/codeunion-config --set hello.world world
$ bin/codeunion-config --unset hello.world
$ bin/codeunion-config --get hello.world
$ bin/codeunion-config --get hello.other
other
```
