### PR TITLE
Individual errors provided when configuration is invalid

### DIFF
--- a/lib/codeunion/command.rb
+++ b/lib/codeunion/command.rb
@@ -5,10 +5,20 @@ module CodeUnion
     # Raised when a command doesn't exist
     class CommandNotFound < StandardError; end
 
-    # Raised when config does not have required fields for a command
+    # Raised when a command is missing required configuration fields
+    #
+    # Example:
+    #   fail(MissingConfig, {
+    #                         :name => "codeunion.api_token",
+    #                         :help => "See: http://codeunion.com/guides/creating-a-codeunion-access-token"
+    #                       }
     class MissingConfig < StandardError
-      def initialize(required_fields)
-        super("Make sure you've `codeunion config set` the following config variables: #{required_fields.join(", ")}")
+      def initialize(field)
+        super("Run 'codeunion config set #{field[:name]} VALUE'#{help_text(field)}")
+      end
+
+      def help_text(field)
+        field[:help] ? "\n#{field[:help]}" : ""
       end
     end
 

--- a/lib/codeunion/command/feedback.rb
+++ b/lib/codeunion/command/feedback.rb
@@ -7,12 +7,18 @@ module CodeUnion
     # "View" in Traditional MVC for the Feedback command. Validates Input
     # and Builds response
     class Feedback < Base
+      CREATE_ACCESS_TOKEN_URL =
+        "https://help.github.com/articles/creating-an-access-token-for-command-line-use/"
+
       def run
         config = Config.load
         token = config.get("github.access_token")
         repository = config.get("feedback.repository")
-        if !token || !repository
-          fail(CodeUnion::Command::MissingConfig, ["github.access_token", "feedback.repository"])
+        if !token
+          fail(CodeUnion::Command::MissingConfig, { :name => "github.access_token",
+                                                    :help => "See: #{CREATE_ACCESS_TOKEN_URL }" })
+        elsif !repository
+          fail(CodeUnion::Command::MissingConfig, { :name => "feedback.repository" })
         end
         @feedback_request = FeedbackRequest.new(input, token, repository)
         ensure_valid_input!


### PR DESCRIPTION
fixes #14 

```
$ bin/codeunion feedback request http://google.com
Woops! You need to configure this command
Run `codeunion config --set` github.access_token VALUE
See: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
```
