### PR TITLE
feedback command defaults to request subcommand

### DIFF
--- a/libexec/codeunion-feedback
+++ b/libexec/codeunion-feedback
@@ -73,10 +73,12 @@ end
 
 top_level_parser.order!
 command = ARGV.shift
-if !command
+
+unless command
   puts top_level_parser
   exit
 end
+
 if command && !commands[command]
   options[:input] = [command]
   command = "request"


### PR DESCRIPTION
Fixes #13

```
$ bin/codeunion feedback http://google.com #now submits a feedback request.
```
