### PR TITLE
Stops clobbering API sort

### DIFF
--- a/lib/codeunion/command/search.rb
+++ b/lib/codeunion/command/search.rb
@@ -25,7 +25,7 @@ module CodeUnion
       end
 
       def results_by_category
-        results.group_by { |result| result["category"] }.sort
+        results.group_by { |result| result["category"] }
       end
 
       def results


### PR DESCRIPTION
Because we do the group_by with a sort, it winds up pushing good results
away. It may be best to not group the results at all; instead denoting
types on a per-entry basis
