### PR TITLE
Results printed in order of search ranking

### DIFF
--- a/lib/codeunion/command/search.rb
+++ b/lib/codeunion/command/search.rb
@@ -14,18 +14,10 @@ module CodeUnion
       include CodeUnion::Helpers::Text
 
       def run
-        results_by_category.flat_map do |name, results|
-          heading = Rainbow("#{name.capitalize}:").color(:red)
-
-          results.inject([heading]) do |lines, result|
-            lines.push(CodeUnion::Search::ResultPresenter.new(result).to_s)
-            lines << format_output("")
-          end
+        results.inject([]) do |lines, result|
+          lines.push(CodeUnion::Search::ResultPresenter.new(result).to_s)
+          lines << format_output("")
         end.join("\n")
-      end
-
-      def results_by_category
-        results.group_by { |result| result["category"] }
       end
 
       def results

--- a/lib/codeunion/search.rb
+++ b/lib/codeunion/search.rb
@@ -13,19 +13,27 @@ module CodeUnion
       end
 
       def to_s
-        [:description, :url, :tags, :excerpt].map do |attribute|
+        [:name, :description, :url, :tags, :excerpt].map do |attribute|
           format_output(send(attribute))
         end.join("\n")
       end
 
       private
 
+      def name
+        "#{category}: " + Rainbow(@result["name"]).color(:blue)
+      end
+
+      def category
+        Rainbow(@result["category"].gsub(/s$/, "").capitalize).color(:red)
+      end
+
       def description
         Rainbow(@result["description"]).color(:yellow)
       end
 
       def excerpt
-        "excerpt: " + @result["excerpt"].gsub(EXCERPT_REGEX) do
+        "Excerpt: " + @result["excerpt"].gsub(EXCERPT_REGEX) do
           query_term = Regexp.last_match[1]
           Rainbow(query_term).color(:blue)
         end + "..."

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -41,6 +41,8 @@ module CodeUnion
       end
 
       def test_presenter_highlights
+        assert_highlights("Example", :red, results[0])
+        assert_highlights("linkedout-example", :blue, results[0])
         assert_highlights("api", :blue, results[0])
         assert_highlights(results[0]["url"], :green, results[0])
         assert_highlights(results[0]["description"], :yellow, results[0])


### PR DESCRIPTION
![screen shot 2015-01-02 at 4 46 18 pm](https://cloud.githubusercontent.com/assets/50284/5601025/1075d3b6-929f-11e4-95de-93520397f339.png)

@openspectrum @jfarmer This is very colorful...

This adds the category and title as the first line for each search result.
