### PR TITLE
Conforms libexec to snake_case instead of dash-case

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Style/Documentation:
 Style/FileName:
   Exclude:
     - 'bin/*'
+    - 'libexec/*'
 
 Style/LineEndConcatenation:
   Enabled: false

--- a/libexec/codeunion-config
+++ b/libexec/codeunion-config
@@ -114,4 +114,3 @@ else
   result = CodeUnion::Command::Config.new(options).run
   puts result if result
 end
-


### PR DESCRIPTION
Because we'd named our commands with a dash between them, rubocop gets
angry:

```
> libexec/codeunion-config:1:1: C: Use snake_case for source file names.
> #!/usr/bin/env ruby
> ^
> libexec/codeunion-config:117:1: C: 1 trailing blank lines detected.
> libexec/codeunion-examples:1:1: C: Use snake_case for source file names.
> #!/usr/bin/env ruby
> ^
> libexec/codeunion-feedback:1:1: C: Use snake_case for source file names.
> #!/usr/bin/env ruby
> ^
> libexec/codeunion-projects:1:1: C: Use snake_case for source file names.
> #!/usr/bin/env ruby
> ^
> libexec/codeunion-search:1:1: C: Use snake_case for source file names.
> #!/usr/bin/env ruby
> ^
```

And we don't like rubocop when they're angry.

@jfarmer any concerns about this?
