### PR TITLE
Add default help message

### DIFF
--- a/bin/codeunion
+++ b/bin/codeunion
@@ -12,6 +12,25 @@ $LOAD_PATH.unshift File.expand_path("../../lib", bin_file)
 ENV["PATH"] += ":" + File.expand_path("../../libexec", bin_file)
 
 require "codeunion/command/main"
+require "optparse"
+
+parser = OptionParser.new do |opts|
+  opts.instance_exec do
+    self.banner = "Usage: codeunion <command>"
+
+    on_tail("-h", "--help", "Print this help message") do
+      puts self
+      exit
+    end
+  end
+end
+
+parser.order!
+
+if ARGV.empty?
+  puts parser
+  exit
+end
 
 options = {
   :command_name => ARGV.first,

--- a/bin/codeunion
+++ b/bin/codeunion
@@ -23,9 +23,18 @@ end
 require "codeunion/command/main"
 require "optparse"
 
+description = <<HELP
+The CodeUnion command-line tool is meant to be used in conjunction with CodeUnion's curriculum.
+
+Think of it as your "learning sherpa."
+HELP
+
 parser = OptionParser.new do |opts|
   opts.instance_exec do
     self.banner = "Usage: codeunion <command>"
+
+    separator ""
+    separator description
 
     separator ""
     separator "Commands:"

--- a/bin/codeunion
+++ b/bin/codeunion
@@ -9,7 +9,16 @@ bin_file = Pathname.new(__FILE__).realpath
 $LOAD_PATH.unshift File.expand_path("../../lib", bin_file)
 
 # Add our gem-specific "libexec" directory to the PATH
-ENV["PATH"] += ":" + File.expand_path("../../libexec", bin_file)
+subcmd_dir = File.expand_path("../../libexec", bin_file)
+ENV["PATH"] += ":" + subcmd_dir
+
+# Find all available subcommands
+subcmd_prefix = "codeunion-"
+subcmd_files  = Pathname.glob(File.join(subcmd_dir, subcmd_prefix + "*"))
+
+SUBCOMMANDS = subcmd_files.map do |path|
+  path.basename.to_s[/#{subcmd_prefix}(.+)/, 1]
+end
 
 require "codeunion/command/main"
 require "optparse"
@@ -17,6 +26,13 @@ require "optparse"
 parser = OptionParser.new do |opts|
   opts.instance_exec do
     self.banner = "Usage: codeunion <command>"
+
+    separator ""
+    separator "Commands:"
+    separator SUBCOMMANDS.map { |subcmd| summary_indent + subcmd }
+
+    separator ""
+    separator "Options:"
 
     on_tail("-h", "--help", "Print this help message") do
       puts self


### PR DESCRIPTION
Running `codeunion` without giving a proper subcommand throws an error. -1 UX.

This is a quick attempt to remedy that:

```shell-session
$ codeunion
Usage: codeunion <command>

The CodeUnion command-line tool is meant to be used in conjunction with CodeUnion's curriculum.

Think of it as your "learning sherpa."

Commands:
    config
    examples
    feedback
    projects
    search

Options:
    -h, --help                       Print this help message

```